### PR TITLE
Added compatibility support for 151 and 153

### DIFF
--- a/arch/arm/mach-stm32/board-dt.c
+++ b/arch/arm/mach-stm32/board-dt.c
@@ -17,6 +17,8 @@ static const char *const stm32_compat[] __initconst = {
 	"st,stm32f746",
 	"st,stm32f769",
 	"st,stm32h743",
+	"st,stm32mp151",
+	"st,stm32mp153",
 	"st,stm32mp157",
 	NULL
 };


### PR DESCRIPTION
Added Device Tree compatibility support for "st,stm32mp151" and "st,stm32mp153"
 because CubeMX generates compatble string for those MPU versions.
 for example: compatible = "st,stm32mp151c-stm32mp151caax-mx", "st,stm32mp151";

Avoid error
sysfs: cannot create duplicate filename '/devices/platform/cpufreq-dt'
kobject_add_internal failed for cpufreq-dt with -EEXIST, don't try to register things with the same name in the same directory.