### PR TITLE
ARM: dts: stm32: use pll4_p for ethernet PTP clock

### DIFF
--- a/arch/arm/boot/dts/stm32mp157c.dtsi
+++ b/arch/arm/boot/dts/stm32mp157c.dtsi
@@ -1822,11 +1822,15 @@
 			clock-names = "stmmaceth",
 				      "mac-clk-tx",
 				      "mac-clk-rx",
-				      "ethstp";
+				      "ethstp",
+				      "ptp_ref";
 			clocks = <&rcc ETHMAC>,
 				 <&rcc ETHTX>,
 				 <&rcc ETHRX>,
-				 <&rcc ETHSTP>;
+				 <&rcc ETHSTP>,
+				 <&rcc ETHPTP_K>;
+			assigned-clocks = <&rcc ETHPTP_K>;
+			assigned-clock-parents = <&rcc PLL4_P>;
 			st,syscon = <&syscfg 0x4>;
 			snps,mixed-burst;
 			snps,pbl = <2>;


### PR DESCRIPTION
IEEE 1588 support needs a clock defined as ptp_ref and this uses pll4_p as the parent clock

before:
$ ./testptp -g ; sleep 1 ; ./testptp -g
clock time: 0.000000000 or Wed Dec 31 18:00:00 1969
clock time: 0.000000000 or Wed Dec 31 18:00:00 1969

after:
$ ./testptp -g ; sleep 1 ; ./testptp -g
clock time: 1587623094.279486315 or Thu Apr 23 01:24:54 2020
clock time: 1587623095.292978915 or Thu Apr 23 01:24:55 2020
