### PR TITLE
Add missing TTY wakeup to rpmsg_tty

### DIFF
--- a/drivers/rpmsg/rpmsg_tty.c
+++ b/drivers/rpmsg/rpmsg_tty.c
@@ -146,6 +146,8 @@ static int rpmsg_tty_write(struct tty_struct *tty, const unsigned char *buf,
 		}
 	} while (count > 0);
 
+	tty_port_tty_wakeup(cport->port);
+
 	return total;
 }
 


### PR DESCRIPTION
The rpmgs_tty driver is missing the call to tty_port_tty_wakeup() after a
successful writing of data.

A line discipline that is configured for the RPMSG tty will as such never
receive the write_wakeup call when space is available for further data.