### PR TITLE
ARM: dts: stm32: Fix issue with usart1 when using no-scmi

### DIFF
--- a/arch/arm/boot/dts/stm32mp15-no-scmi.dtsi
+++ b/arch/arm/boot/dts/stm32mp15-no-scmi.dtsi
@@ -154,4 +154,5 @@
 
 &usart1 {
 	clocks = <&rcc USART1_K>;
+	resets = <&rcc USART1_R>;
 };


### PR DESCRIPTION
Add a reset to usart1 for consistency. Without it, it won't compile.

Signed-off-by: Daniel Ammann <daniel.ammann@bytesatwork.ch>