### PR TITLE
include: uapi: serial: Fix for serial_rs485 struct

### DIFF
--- a/include/uapi/linux/serial.h
+++ b/include/uapi/linux/serial.h
@@ -130,7 +130,7 @@ struct serial_rs485 {
 	__u32	delay_rts_after_send;	/* Delay after send (milliseconds) */
 	__u32	delay_rts_before_send_ns;	/* Delay (nanoseconds) */
 	__u32	delay_rts_after_send_ns;	/* Delay (nanoseconds) */
-	__u32	padding[5];		/* Memory is cheap, new structs
+	__u32	padding[3];		/* Memory is cheap, new structs
 					   are a royal PITA .. */
 };
 


### PR DESCRIPTION
For backward compatibility, keep structure of serial_rs485 the same size. 

Fix for: bfdca4682564e499b4cf1a3d1904387d2cb528c3