### PR TITLE
drm/stm: ltdc: fix pinctrl recovery after sleep

### DIFF
--- a/drivers/gpu/drm/stm/ltdc.c
+++ b/drivers/gpu/drm/stm/ltdc.c
@@ -1134,6 +1134,14 @@ static void ltdc_encoder_enable(struct drm_encoder *encoder)
 
 	DRM_DEBUG_DRIVER("\n");
 
+	/*
+	 * Set to default state the pinctrl only with DPI type.
+	 * Others types like DSI, don't need pinctrl due to
+	 * internal bridge (the signals do not come out of the chipset).
+	 */
+	if (encoder->encoder_type == DRM_MODE_ENCODER_DPI)
+		pinctrl_pm_select_default_state(ddev->dev);
+
 	/* Enable LTDC */
 	reg_set(ldev->regs, LTDC_GCR, GCR_LTDCEN);
 }
@@ -1146,11 +1154,7 @@ static void ltdc_encoder_mode_set(struct drm_encoder *encoder,
 
 	DRM_DEBUG_DRIVER("\n");
 
-	/*
-	 * Set to default state the pinctrl only with DPI type.
-	 * Others types like DSI, don't need pinctrl due to
-	 * internal bridge (the signals do not come out of the chipset).
-	 */
+	/* Set pinctrl to default as soon as possible */
 	if (encoder->encoder_type == DRM_MODE_ENCODER_DPI)
 		pinctrl_pm_select_default_state(ddev->dev);
 }


### PR DESCRIPTION
I encountered a problem where an RGB TFT LCD panel attached to an STM32MP1 would stop working after the framebuffer was put to sleep and woken back up. The reason was that the sleep pinctrl was applied when the framebuffer went to sleep, but the default pinctrl wasn't being restored after the LTDC woke up. This is because an older commit moved the LTDC default pinctrl configuration to ltdc_encoder_mode_set, which doesn't get called again after it wakes up.

This fix was tested in the v5.4-stm32mp branch on a custom STM32MP1 board. I tested by blanking and then unblanking the framebuffer. Before this fix, the LCD display got garbled after unblanking. With this fix, it recovers correctly.

`echo 1 > /sys/class/graphics/fb0/blank`
`echo 0 > /sys/class/graphics/fb0/blank`