### PR TITLE
Add support to run 800MHz speed grade parts at 650MHz

### DIFF
--- a/arch/arm/boot/dts/stm32mp15xa.dtsi
+++ b/arch/arm/boot/dts/stm32mp15xa.dtsi
@@ -8,6 +8,6 @@
 		opp-650000000 {
 			opp-hz = /bits/ 64 <650000000>;
 			opp-microvolt = <1200000>;
-			opp-supported-hw = <0x1>;
+			opp-supported-hw = <0x1 0x2>;
 		};
 };


### PR DESCRIPTION
This patch allows running 800MHz speed grade superset devices at 650MHz by adding OPP hardware ID of 800MHz speed grade parts to 650MHz OPP table.