### PR TITLE
usb: dwc2: hcd: add missing ifdeffery for hsotg->test_mode

### DIFF
--- a/drivers/usb/dwc2/hcd.c
+++ b/drivers/usb/dwc2/hcd.c
@@ -3718,7 +3718,10 @@ static int dwc2_hcd_hub_control(struct dwc2_hsotg *hsotg, u16 typereq,
 			hprt0 &= ~HPRT0_TSTCTL_MASK;
 			hprt0 |= (windex >> 8) << HPRT0_TSTCTL_SHIFT;
 			dwc2_writel(hsotg, hprt0, HPRT0);
+#if IS_ENABLED(CONFIG_USB_DWC2_PERIPHERAL) || \
+	IS_ENABLED(CONFIG_USB_DWC2_DUAL_ROLE)
 			hsotg->test_mode = windex >> 8;
+#endif
 			break;
 
 		default:


### PR DESCRIPTION
In the struct dwc2_hsotg, the test_mode member is only present in gadget or dual role mode.

Add a ifdeffery to fix a compile issue if the driver is built in host mode only.

Fixes: da4d73819312 ("usb: dwc2: hcd: initialize hsotg->test_mode upon USB_PORT_FEAT_TEST")