### PR TITLE
Allow IPCC bi-directional communication

### DIFF
--- a/arch/arm/boot/dts/stm32mp157f-ed1.dts
+++ b/arch/arm/boot/dts/stm32mp157f-ed1.dts
@@ -359,7 +359,7 @@
 &m4_rproc {
 	memory-region = <&retram>, <&mcuram>, <&mcuram2>, <&vdev0vring0>,
 			<&vdev0vring1>, <&vdev0buffer>, <&mcu_rsc_table>;
-	mboxes = <&ipcc 0>, <&ipcc 1>, <&ipcc 2>, <&ipcc 3>;
+	mboxes = <&ipcc 0>, <&ipcc 3>, <&ipcc 5>, <&ipcc 7>;
 	mbox-names = "vq0", "vq1", "shutdown", "detach";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;


### PR DESCRIPTION
Hello,

I did some exploratory work on the stm32mp157f-ev1 board and one of the functionalities I tested was inter-processor communication using the IPCC.
As a reminder, the IPCC is described in the documentation as a bank of bi-directional channels [1].
I used examples of full duplex communication from ST.

During my tests, it seems that the "buf free" message is not sent by either the Cortex-A7 or the Cortex-M4 [2].
So these examples use IPCC channels in one direction only.

However, we are not able to use them in both directions at the same time and, in consequence, to fully use the hardware capacity as it is described in the documentation.
This is due to the association between IPCC, MAILBOX and REMOTEPROC.
The number of MAILBOX is the same as the number of IPCC channels. So MAILBOX should work in reception and transmission at the same time.
But, in REMOTEPROC, a virtual queue (VQ) is assigned to MAILBOX instances. VQ0 is used in the receive direction and VQ1 in the transmit direction. So MAILBOX is actually locked in a single direction.
To be able to use IPCC channels in both receive and transmit way, we could define the MAILBOX to be associated with an IPCC subchannel.


[1] https://wiki.st.com/stm32mpu/wiki/IPCC_internal_peripheral#Peripheral_overview
[2] Comment found in STM32CubeMP1/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo/Src/mbox_ipcc.c

```
/*
 * Channel direction and usage:
 *
 *  ========   <-- new msg ---=============--------<------   =======
 * ||      ||                || CHANNEL 1 ||                ||     ||
 * ||  A7  ||  ------->-------=============--- buf free-->  || M4  ||
 * ||      ||                                               ||     ||
 * ||master||  <-- buf free---=============--------<------  ||slave||
 * ||      ||                || CHANNEL 2 ||                ||     ||
 *  ========   ------->-------=============----new msg -->   =======
 */
```