### PR TITLE
fix(rifsc): remove unused parameter in stm32_rifsc_register_debugfs when DEBUG_FS is not set

### DIFF
--- a/drivers/bus/stm32_rifsc.c
+++ b/drivers/bus/stm32_rifsc.c
@@ -633,7 +633,7 @@ static int stm32_rifsc_register_debugfs(struct rifsc_private *priv)
 	return 0;
 }
 #else /* CONFIG_DEBUG_FS */
-static int stm32_rifsc_register_debugfs(struct rifsc_private *priv __unused)
+static int stm32_rifsc_register_debugfs(struct rifsc_private *__unused)
 {
 	return 0;
 }


### PR DESCRIPTION
This is the error I got when I compile the kernel without the CONFIG_DEBUG_FS option:
```
| ../../../../../../kernel-source/drivers/bus/stm32_rifsc.c:636:68: error: expected ';', ',' or ')' before '__unused'
|   636 | static int stm32_rifsc_register_debugfs(struct rifsc_private *priv __unused)
|       |                                                                    ^~~~~~~~
| ../../../../../../kernel-source/drivers/bus/stm32_rifsc.c: In function 'stm32_rifsc_probe':
| ../../../../../../kernel-source/drivers/bus/stm32_rifsc.c:910:14: error: implicit declaration of function 'stm32_rifsc_register_debugfs' [-Werror=implicit-function-declaration]
|   910 |         rc = stm32_rifsc_register_debugfs(rifsc_priv);
|       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
| cc1: some warnings being treated as errors
```

Feel free to forward this fix to your internal team if you don't want to merge my PR.