### PR TITLE
arm64: dts: st: add MMC aliases on stm32mp257f-ev1

### DIFF
--- a/arch/arm64/boot/dts/st/stm32mp257f-ev1.dts
+++ b/arch/arm64/boot/dts/st/stm32mp257f-ev1.dts
@@ -23,6 +23,8 @@
 	aliases {
 		ethernet0 = &eth2;
 		ethernet1 = &eth1;
+		mmc0 = &sdmmc1;
+		mmc1 = &sdmmc2;
 		serial0 = &usart2;
 		serial1 = &usart6;
 		serial2 = &lpuart1;


### PR DESCRIPTION
Add MMC aliases to ensure that the /dev/mmcblk IDs won't change depending on the probe order of the MMC drivers.