### PR TITLE
Fix the issue of loading cm33 elf built by IAR

### DIFF
--- a/drivers/remoteproc/stm32_rproc.c
+++ b/drivers/remoteproc/stm32_rproc.c
@@ -153,7 +153,8 @@ static u64 stm32_rproc_get_vect_table(struct rproc *rproc, const struct firmware
 		u64 offset = elf_shdr_get_sh_offset(class, shdr);
 		u32 name = elf_shdr_get_sh_name(class, shdr);
 
-		if (strcmp(name_table + name, ".isr_vectors"))
+		if (strcmp(name_table + name, ".isr_vectors")&&
+			strcmp(name_table + name, "A0"))
 			continue;
 
 		/* make sure we have the entire table */


### PR DESCRIPTION
Fix the issue of elf load from Linux for the elf built by IAR.
When looking for the boot address info from elf, make it compatible check for section name of both ".isr_vector" (CubeIDE) and "A0" (IAR).

Signed-off-by: sunny.chen@st.com