### PR TITLE
drm/bridge: adv7533: don't force 3/4 DSI lanes on non-4-lane boards

### DIFF
--- a/drivers/gpu/drm/bridge/adv7511/adv7533.c
+++ b/drivers/gpu/drm/bridge/adv7511/adv7533.c
@@ -127,6 +127,17 @@ bool adv7533_mode_fixup(struct adv7511 *adv,
 	struct mipi_dsi_device *dsi = adv->dsi;
 	int lanes, ret;
 
+	/*
+	 * Only 4-lane designs support switching between 3 and 4 lanes
+	 * depending on pixel clock; boards wired for 2 or 3 lanes must
+	 * keep the lane count fixed at what was set from DT. Otherwise
+	 * this would force a lane count that doesn't match what is
+	 * physically wired (e.g. forcing 3 lanes on a 2-lane design),
+	 * leaving the display blank.
+	 */
+	if (dsi->lanes != 4)
+		return true;
+
 	if (mode->clock > 80000)
 		lanes = 4;
 	else


### PR DESCRIPTION
drm/bridge: adv7533: don't force 3/4 DSI lanes on non-4-lane boards

adv7533_mode_fixup() always forces dsi->lanes to either 3 or 4
lanes depending on the pixel clock, regardless of how many DSI
lanes are physically wired to the bridge. On boards where only
2 (or 3) lanes are connected, this overrides the lane count that
was correctly set from the "adi,dsi-lanes" DT property, causing
the ADV7533 DSI_PCONFR NL field to be programmed with a lane
count that doesn't match the hardware, leaving the display
blank.

Only 4-lane designs can safely alternate between 3 and 4 lanes
depending on bandwidth needs. Boards wired for 2 or 3 lanes must
keep the lane count fixed at what adv7533_attach_dsi() set from
DT, so skip the dynamic switch unless num_dsi_lanes == 4.

Link: https://community.st.com/stm32-mpus-products-and-hardware-related-39/issue-using-dsi-to-hdmi-adapter-b-lcdad-hdmi1-adv7533-bridge-with-stm32mp25f-161862
Suggested-by: MBassi
Signed-off-by: Khaled ELAGHA <eng.khaled.elagha@gmail.com>